### PR TITLE
Fix for non-existent task

### DIFF
--- a/scheduler/models/scheduled_task.py
+++ b/scheduler/models/scheduled_task.py
@@ -33,6 +33,7 @@ def failure_callback(job, connection, result, *args, **kwargs):
     model = apps.get_model(app_label='scheduler', model_name=model_name)
     task = model.objects.filter(job_id=job.id).first()
     if task is None:
+        logger.warn(f'Could not find {model_name} task for job {job.id}')
         return
     mail_admins(f'Task {task.id}/{task.name} has failed',
                 'See django-admin for logs', )

--- a/scheduler/models/scheduled_task.py
+++ b/scheduler/models/scheduled_task.py
@@ -32,10 +32,10 @@ def failure_callback(job, connection, result, *args, **kwargs):
         return
     model = apps.get_model(app_label='scheduler', model_name=model_name)
     task = model.objects.filter(job_id=job.id).first()
-    mail_admins(f'Task {task.id}/{task.name} has failed',
-                'See django-admin for logs', )
     if task is None:
         return
+    mail_admins(f'Task {task.id}/{task.name} has failed',
+                'See django-admin for logs', )
     task.job_id = None
     task.save(schedule_job=True)
 


### PR DESCRIPTION
Hi @cunla !
Useful when rq, database in a bad state (especially when using docker locally)
(was about to create an issue first, but this is quite straight-forward)

relevant logs:

```
abc_cde_app-wkr-1    |   File "/usr/local/lib/python3.11/site-packages/scheduler/tools.py", line 37, in get_scheduled_task
abc_cde_app-wkr-1    |     raise ValueError(f'Job {task_model}:{task_id} does not exit')
abc_cde_app-wkr-1    | ValueError: Job CronTask:66 does not exit
abc_cde_app-wkr-1    | 
abc_cde_app-wkr-1    | During handling of the above exception, another exception occurred:
abc_cde_app-wkr-1    | 
abc_cde_app-wkr-1    | Traceback (most recent call last):
abc_cde_app-wkr-1    |   File "/usr/local/lib/python3.11/site-packages/rq/job.py", line 1429, in execute_failure_callback
abc_cde_app-wkr-1    |     self.failure_callback(self, self.connection, *exc_info)
abc_cde_app-wkr-1    |   File "/usr/local/lib/python3.11/site-packages/scheduler/models/scheduled_task.py", line 35, in failure_callback
abc_cde_app-wkr-1    |     mail_admins(f'Task {task.id}/{task.name} has failed',
abc_cde_app-wkr-1    |                         ^^^^^^^
abc_cde_app-wkr-1    | AttributeError: 'NoneType' object has no attribute 'id'
abc_cde_app-wkr-1    | 00:20:06 [Job default:Verify Presubmitted Audit Records:87ffafee18]: exception raised while executing (scheduler.tools.run_task)
abc_cde_app-wkr-1    | Traceback (most recent call last):
abc_cde_app-wkr-1    |   File "/usr/local/lib/python3.11/site-packages/rq/worker.py", line 1428, in perform_job
abc_cde_app-wkr-1    |     rv = job.perform()
abc_cde_app-wkr-1    |          ^^^^^^^^^^^^^
abc_cde_app-wkr-1    |   File "/usr/local/lib/python3.11/site-packages/rq/job.py", line 1278, in perform
abc_cde_app-wkr-1    |     self._result = self._execute()
abc_cde_app-wkr-1    |                    ^^^^^^^^^^^^^^^
abc_cde_app-wkr-1    |   File "/usr/local/lib/python3.11/site-packages/rq/job.py", line 1315, in _execute
abc_cde_app-wkr-1    |     result = self.func(*self.args, **self.kwargs)
abc_cde_app-wkr-1    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
abc_cde_app-wkr-1    |   File "/usr/local/lib/python3.11/site-packages/scheduler/tools.py", line 44, in run_task
abc_cde_app-wkr-1    |     scheduled_task = get_scheduled_task(task_model, task_id)
abc_cde_app-wkr-1    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
abc_cde_app-wkr-1    |   File "/usr/local/lib/python3.11/site-packages/scheduler/tools.py", line 37, in get_scheduled_task
abc_cde_app-wkr-1    |     raise ValueError(f'Job {task_model}:{task_id} does not exit')
abc_cde_app-wkr-1    | ValueError: Job CronTask:66 does not exit
abc_cde_app-wkr-1    | 
abc_cde_app-wkr-1    | During handling of the above exception, another exception occurred:
abc_cde_app-wkr-1    | 
abc_cde_app-wkr-1    | Traceback (most recent call last):
abc_cde_app-wkr-1    |   File "/usr/local/lib/python3.11/site-packages/rq/worker.py", line 1449, in perform_job
abc_cde_app-wkr-1    |     job.execute_failure_callback(self.death_penalty_class, *exc_info)
abc_cde_app-wkr-1    |   File "/usr/local/lib/python3.11/site-packages/rq/job.py", line 1429, in execute_failure_callback
abc_cde_app-wkr-1    |     self.failure_callback(self, self.connection, *exc_info)
abc_cde_app-wkr-1    |   File "/usr/local/lib/python3.11/site-packages/scheduler/models/scheduled_task.py", line 35, in failure_callback
abc_cde_app-wkr-1    |     mail_admins(f'Task {task.id}/{task.name} has failed',
abc_cde_app-wkr-1    |                         ^^^^^^^
abc_cde_app-wkr-1    | AttributeError: 'NoneType' object has no attribute 'id'
```