### PR TITLE
Removes psycopg2 dependency from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,8 @@ classifiers = [
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
     'Framework :: Django',
+    'Framework :: Django :: 5',
+    'Framework :: Django :: 5.0',
     'Framework :: Django :: 4',
     'Framework :: Django :: 4.0',
     'Framework :: Django :: 4.1',
@@ -51,7 +53,6 @@ croniter = "^2.0.1"
 click = "^8.1"
 rq = "^1.15"
 pyyaml = { version = "^6.0", optional = true }
-psycopg2 = "^2.9.9"
 
 [tool.poetry.dev-dependencies]
 poetry = "^1.7.1"


### PR DESCRIPTION
This fixes #77 by removing the psycopg2 dependency from pyproject.toml. 
Also updates the trove classifiers to include Django 5, since it's supported.